### PR TITLE
사용자 역할에 따른 페이지 라우팅

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,11 +4,9 @@ import React from 'react';
 
 import { Route, Switch } from 'react-router-dom';
 
-import LoginPage from './pages/LoginPage';
 import SignUpSelectPage from './pages/SignUpSelectPage';
 import RiderSignUpPage from './pages/RiderSignUpPage';
 import DriverSignUpPage from './pages/DriverSignUpPage';
-import DriverWaitingPage from './pages/DriverWaitingPage';
 
 import RouteIf from './routes/RouteIf';
 
@@ -16,11 +14,9 @@ export default function App() {
   return (
     <>
       <Switch>
-        <Route path='/driver/main' component={DriverWaitingPage} />
         <Route path='/signup/select' component={SignUpSelectPage} />
         <Route path='/signup/rider' component={RiderSignUpPage} />
         <Route path='/signup/driver' component={DriverSignUpPage} />
-        <Route path='/login' component={LoginPage} />
         <RouteIf path='*' />
       </Switch>
     </>

--- a/client/src/apis/loginAPI.tsx
+++ b/client/src/apis/loginAPI.tsx
@@ -1,6 +1,8 @@
 import { loginRiderQuery, loginDriverQuery } from '../queries/login';
 
-export const requestLogin = async (client: any, history: any, riderCheck : boolean, email: string, password: string) => {
+import { setLoginRole } from '../slices/loginSlice';
+
+export const requestLogin = async (client: any, history: any, riderCheck : boolean, email: string, password: string, dispatch: any) => {
   const { data } = await client.mutate({
     mutation: riderCheck ? loginRiderQuery : loginDriverQuery,
     variables: { email, password },
@@ -11,6 +13,7 @@ export const requestLogin = async (client: any, history: any, riderCheck : boole
 
   if (success) {
     localStorage.setItem('token', token);
+    dispatch(setLoginRole(role));
     riderCheck ? history.push('/setcourse') : history.push('/driver/main');
   } else {
     window.alert(message);

--- a/client/src/apis/loginAPI.tsx
+++ b/client/src/apis/loginAPI.tsx
@@ -11,7 +11,7 @@ export const requestLogin = async (client: any, history: any, riderCheck : boole
 
   if (success) {
     localStorage.setItem('token', token);
-    riderCheck ? history.push('/setcourse') : history.push('/signup/select');
+    riderCheck ? history.push('/setcourse') : history.push('/driver/main');
   } else {
     window.alert(message);
   }

--- a/client/src/apis/verifyUserAPI.tsx
+++ b/client/src/apis/verifyUserAPI.tsx
@@ -8,5 +8,5 @@ export const verifyUser = async (client: any, dispatch: any) => {
     fetchPolicy: 'no-cache',
   });
 
-  !!data.verifyUser.role ? dispatch(setLoginRole(data.verifyUser.role)) : dispatch(setLoginRole('null'));
+  !!data.verifyUser.role ? dispatch(setLoginRole(data.verifyUser.role)) : dispatch(setLoginRole('unknown'));
 };

--- a/client/src/apis/verifyUserAPI.tsx
+++ b/client/src/apis/verifyUserAPI.tsx
@@ -1,0 +1,12 @@
+import { verifyQuery } from '../queries/verify';
+
+import { setLoginRole } from '../slices/loginSlice';
+
+export const verifyUser = async (client: any, dispatch: any) => {
+  const { data } = await client.mutate({
+    mutation: verifyQuery,
+    fetchPolicy: 'no-cache',
+  });
+
+  !!data.verifyUser.role ? dispatch(setLoginRole(data.verifyUser.role)) : dispatch(setLoginRole('null'));
+};

--- a/client/src/components/containers/LoginForm.tsx
+++ b/client/src/components/containers/LoginForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 
 import { useApolloClient } from '@apollo/client';
 
@@ -7,12 +8,11 @@ import { WhiteSpace, Checkbox } from 'antd-mobile';
 
 import styled from 'styled-components';
 
-import Input from '../presentational/Input';
-
 import { requestLogin } from '../../apis/loginAPI';
 
 import { checkValidation } from '../../utils/validate';
 
+import Input from '../presentational/Input';
 import SubmitButton from '../presentational/SubmitButton';
 
 const Div = styled.div`
@@ -46,6 +46,7 @@ const SignupButton = styled.button`
 function LoginForm() {
   const client = useApolloClient();
   const history = useHistory();
+  const dispatch = useDispatch();
 
   const [riderCheck, setRiderCheck] = useState(true);
   const [driverCheck, setDriverCheck] = useState(false);
@@ -58,7 +59,7 @@ function LoginForm() {
   };
 
   const handleLoginButtonClick = () => {
-    requestLogin(client, history, riderCheck, email, password);
+    requestLogin(client, history, riderCheck, email, password, dispatch);
   };
 
   const checkToggle = (e: any) => {

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -6,7 +6,8 @@ import { BrowserRouter } from 'react-router-dom';
 
 import { Provider } from 'react-redux';
 
-import { ApolloProvider, ApolloClient, InMemoryCache } from '@apollo/client';
+import { ApolloProvider, ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
 
 import GlobalStyle from './GlobalStyle';
 import store from './store';
@@ -14,8 +15,22 @@ import App from './App';
 
 const rootElement = document.getElementById('app');
 
-const client = new ApolloClient({
+const httpLink = createHttpLink({
   uri: process.env.REACT_APP_SERVER_URI,
+});
+
+const authLink = setContext((_, { headers }) => {
+  const token = localStorage.getItem('token');
+  return {
+    headers: {
+      ...headers,
+      authorization: token ? `Bearer ${token}` : '',
+    },
+  };
+});
+
+const client = new ApolloClient({
+  link: authLink.concat(httpLink),
   cache: new InMemoryCache(),
 });
 

--- a/client/src/queries/verify.ts
+++ b/client/src/queries/verify.ts
@@ -1,0 +1,9 @@
+import { gql } from '@apollo/client';
+
+export const verifyQuery = gql`
+  query verifyUser {
+    verifyUser {
+      role
+    }
+  }
+`;

--- a/client/src/routes/RouteIf.tsx
+++ b/client/src/routes/RouteIf.tsx
@@ -47,7 +47,7 @@ const RouteIf: FunctionComponent<Paths> = ({ path }) => {
             </Switch>
           );
         }
-        if (loginReducer.loginRole === 'null') {
+        if (loginReducer.loginRole === 'unknown') {
           localStorage.removeItem('token');
           return (
             <Switch>

--- a/client/src/routes/RouteIf.tsx
+++ b/client/src/routes/RouteIf.tsx
@@ -4,25 +4,58 @@ import {
   BrowserRouter as Router, Switch, Route, Redirect,
 } from 'react-router-dom';
 
+import { useApolloClient } from '@apollo/client';
+
+import { useSelector, useDispatch } from 'react-redux';
+
+import { verifyUser } from '../apis/verifyUserAPI';
+
 import SetCoursePage from '../pages/SetCoursePage';
+import DriverWaitingPage from '../pages/DriverWaitingPage';
+import LoginPage from '../pages/LoginPage';
+
 interface Paths {
   path: string;
 }
 
 const RouteIf: FunctionComponent<Paths> = ({ path }) => {
+  const client = useApolloClient();
+  const dispatch = useDispatch();
+  const { loginReducer }: any = useSelector((state: any) => state);
+
   return (
     <Route
       path={path}
       render={() => {
-        if (localStorage.getItem('token')) {
+        if (loginReducer.loginRole === '') {
+          verifyUser(client, dispatch);
+          return;
+        }
+        if (loginReducer.loginRole === 'driver') {
+          return (
+            <Switch>
+              <Route path='/driver/main' component={DriverWaitingPage} />
+              <Redirect path="*" to="/driver/main" />
+            </Switch>
+          );
+        }
+        if (loginReducer.loginRole === 'rider') {
           return (
             <Switch>
               <Route path='/setcourse' component={SetCoursePage} />
+              <Redirect path="*" to="/setcourse" />
+            </Switch>
+          );
+        }
+        if (loginReducer.loginRole === 'null') {
+          localStorage.removeItem('token');
+          return (
+            <Switch>
+              <Route path='/login' component={LoginPage} />
               <Redirect path="*" to="/login" />
             </Switch>
           );
         }
-        return <Redirect to="/login"/>;
       }}
     />
   );

--- a/client/src/slices/index.ts
+++ b/client/src/slices/index.ts
@@ -1,9 +1,11 @@
 import { combineReducers } from 'redux';
 
 import mapReducer from './mapSlice';
+import loginReducer from './loginSlice';
 
 const reducer = combineReducers({
   mapReducer,
+  loginReducer,
 });
 
 export default reducer;

--- a/client/src/slices/loginSlice.ts
+++ b/client/src/slices/loginSlice.ts
@@ -1,0 +1,19 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const { actions, reducer } = createSlice({
+  name: 'login',
+  initialState: {
+    loginRole: '',
+  },
+  reducers: {
+    setLoginRole(state, { payload }) {
+      return { ...state, loginRole: payload };
+    },
+  },
+});
+
+export const {
+  setLoginRole,
+} = actions;
+
+export default reducer;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -28,13 +28,13 @@ const server = new ApolloServer({
   context: ({ req, res }) => buildContext({ req, res }),
   subscriptions: {
     onConnect: (connectionParams, webSocket, context) => {
-      console.log("connected");
+      console.log('connected');
     },
     onDisconnect: (webSocket, context) => {
-      console.log("disconnected");
+      console.log('disconnected');
     },
-  }, });
-  
+  } });
+
 const app = express();
 const path = '/graphql';
 
@@ -56,6 +56,6 @@ const httpServer = http.createServer(app);
 server.installSubscriptionHandlers(httpServer);
 
 httpServer.listen(process.env.PORT, () => {
-  console.log(`🚀 Server ready at http://localhost:${process.env.PORT}${server.graphqlPath}`)
-  console.log(`🚀 Subscriptions ready at ws://localhost:${process.env.PORT}${server.subscriptionsPath}`)
-})
+  console.log(`🚀 Server ready at http://localhost:${process.env.PORT}${server.graphqlPath}`);
+  console.log(`🚀 Subscriptions ready at ws://localhost:${process.env.PORT}${server.subscriptionsPath}`);
+});

--- a/server/src/graphql/resolvers/verify.ts
+++ b/server/src/graphql/resolvers/verify.ts
@@ -1,0 +1,7 @@
+export default {
+  Query: {
+    async verifyUser(parent: any, args: {}, context: any, info: any) {
+      return { role: context.req.user ? context.req.user.isDriver ? 'driver' : 'rider' : '' };
+    },
+  },
+};

--- a/server/src/graphql/types/verify.graphql
+++ b/server/src/graphql/types/verify.graphql
@@ -1,0 +1,7 @@
+type VerifyUser {
+  role: String!
+}
+
+type Query {
+  verifyUser: VerifyUser
+}

--- a/server/src/graphql/types/verify.graphql
+++ b/server/src/graphql/types/verify.graphql
@@ -1,7 +1,7 @@
-type VerifyUser {
+type VerifiedUser {
   role: String!
 }
 
 type Query {
-  verifyUser: VerifyUser
+  verifyUser: VerifiedUser
 }


### PR DESCRIPTION
## 개요

- rider는 rider페이지에만, driver는 driver페이지에만 접근할 수 있도록 한다
- 사용자역할 관리는 조작이 불가능한 redux store에서 한다
- 새로 고침 시 store가 초기화되므로, 페이지가 새로고쳐질 때 마다 서버와 통신하여 사용자의 역할을 store에 새로 저장한다.

## 작업사항

- server에 사용자 검증 resolver 구현
- client의 모든 요청의 header에 token값 추가
- 자신과 관련된 페이지에만 접근할 수 있도록 Routing처리

## 기타