### PR TITLE
Trip Schema 정의 & Driver Schema 업데이트

### DIFF
--- a/server/src/models/driver.ts
+++ b/server/src/models/driver.ts
@@ -1,15 +1,17 @@
 import mongoose, { Document } from 'mongoose';
 const { Schema, model } = mongoose;
 
-type driverInterface = {
-  email: String,
-  name: String,
-  password: String,
-  phoneNumber: String,
-  carType: String,
-  plateNumber: String,
-  description: String,
-  profileImage: String,
+interface driverInterface {
+  email: string;
+  name: string;
+  password: string;
+  phoneNumber: string;
+  carType: string;
+  plateNumber: string;
+  description: string;
+  profileImage: string;
+  latitude: number;
+  longitude: number;
 }
 
 const driverSchema = new Schema({
@@ -21,6 +23,8 @@ const driverSchema = new Schema({
   plateNumber: { type: String, unique: true, required: true },
   description: String,
   profileImage: String,
+  latitude: Number,
+  longitude: Number,
 });
 
 export default model<driverInterface & Document>('Driver', driverSchema);

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -1,4 +1,5 @@
 import Driver from './driver';
 import Rider from './rider';
+import Trip from './trip';
 
-export { Driver, Rider };
+export { Driver, Rider, Trip };

--- a/server/src/models/rider.ts
+++ b/server/src/models/rider.ts
@@ -1,11 +1,11 @@
 import mongoose, { Document } from 'mongoose';
 const { Schema, model } = mongoose;
 
-type riderInterface = {
-  email: String,
-  name: String,
-  password: String,
-  phoneNumber: String,
+interface riderInterface {
+  email: string;
+  name: string;
+  password: string;
+  phoneNumber: string;
 }
 
 const riderSchema = new Schema({

--- a/server/src/models/trip.ts
+++ b/server/src/models/trip.ts
@@ -1,0 +1,69 @@
+import { ObjectID } from 'mongodb';
+import mongoose, { Document } from 'mongoose';
+const { Schema, model } = mongoose;
+
+interface Place {
+  address: string;
+  latitude: number;
+  longitude: number;
+}
+
+interface Driver {
+  _id: string;
+  email: string;
+  name: string;
+  carType: string;
+  plateNumber: string;
+  description: string;
+  profileImage: string;
+}
+
+interface Rider {
+  _id: string;
+  email: string;
+  name: string;
+}
+
+interface TripInterface {
+  origin: Place;
+  destination: Place;
+  startTime: Date;
+  arrivalTime: Date;
+  status: 'open' | 'matched' | 'close' | 'cancel';
+  distance: number;
+  driver: Driver;
+  rider: Rider;
+}
+
+const tripSchema = new Schema({
+  origin: {
+    address: { type: String, required: true },
+    latitude: { type: Number, required: true },
+    longitude: { type: Number, required: true },
+  },
+  destination: {
+    address: { type: String, required: true },
+    latitude: { type: Number, required: true },
+    longitude: { type: Number, required: true },
+  },
+  startTime: { type: Date, required: true },
+  arrivalTime: { type: Date, required: true },
+  status: { type: String, required: true },
+  distance: Number,
+  rider: {
+    _id: { type: ObjectID, required: true },
+    email: { type: String, required: true },
+    name: { type: String, required: true },
+  },
+  driver: {
+    _id: ObjectID,
+    email: String,
+    name: String,
+    carType: String,
+    plateNumber: String,
+    description: String,
+    profileImage: String,
+  },
+});
+
+export default model<TripInterface & Document>('Trip', tripSchema);

--- a/server/src/repositories/index.ts
+++ b/server/src/repositories/index.ts
@@ -1,4 +1,5 @@
 import Driver from './driver';
 import Rider from './rider';
+import Trip from './trip';
 
-export { Driver, Rider };
+export { Driver, Rider, Trip };

--- a/server/src/repositories/trip.ts
+++ b/server/src/repositories/trip.ts
@@ -1,0 +1,3 @@
+import { Trip } from '../models';
+
+export default {};

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,4 +1,5 @@
 import Rider from './rider';
 import Driver from './driver';
+import Trip from './trip';
 
-export { Rider, Driver };
+export { Rider, Driver, Trip };

--- a/server/src/services/trip.ts
+++ b/server/src/services/trip.ts
@@ -1,0 +1,5 @@
+import bcrypt from 'bcrypt';
+
+import { Trip } from '../repositories';
+
+export default {};


### PR DESCRIPTION
## 개요

Database에 운행 정보를 저장하기 위해서 Trip Schema 정의하고 Model 생성

## 작업사항

- Trip Schema 정의
```
{
  origin: {
    address: { type: String, required: true },
    latitude: { type: Number, required: true },
    longitude: { type: Number, required: true },
  },
  destination: {
    address: { type: String, required: true },
    latitude: { type: Number, required: true },
    longitude: { type: Number, required: true },
  },
  startTime: { type: Date, required: true },
  arrivalTime: { type: Date, required: true },
  status: { type: String, required: true },
  distance: Number,
  rider: {
    _id: { type: ObjectID, required: true },
    email: { type: String, required: true },
    name: { type: String, required: true },
  },
  driver: {
    _id: ObjectID,
    email: String,
    name: String,
    carType: String,
    plateNumber: String,
    description: String,
    profileImage: String,
  },
}
```
- Driver Schema에 `latitude`, `longitude` field 추가
- erdCloud 업데이트
- trip repository, service 구조 추가

## 기타

- model에서 Typescript type 선언하는 style 변경 
    - type -> interface 변경
    - 기본 타입 소문자로
    - 세미콜론으로 구분하도록 변경