### PR TITLE
matchedDriverState subscription 및 실시간 위치공유 구현

### DIFF
--- a/client/src/apis/driverAPI.tsx
+++ b/client/src/apis/driverAPI.tsx
@@ -1,0 +1,17 @@
+import { driverStateNotifyQuery } from '../queries/driver';
+
+interface driverStateNotifyProps {
+  operationId: String
+  driverId: String
+  riderId: String
+  driverPosition: String
+  isDrop: Boolean
+}
+
+export const driverStateNotify = async (client: any, driverState: driverStateNotifyProps) => {
+  const { data } = await client.mutate({
+    mutation: driverStateNotifyQuery,
+    variables: driverState,
+    fetchPolicy: 'no-cache',
+  });
+};

--- a/client/src/apis/driverAPI.tsx
+++ b/client/src/apis/driverAPI.tsx
@@ -1,17 +1,25 @@
 import { driverStateNotifyQuery } from '../queries/driver';
 
+interface driverPosition {
+  lat: number
+  lng: number
+}
+
 interface driverStateNotifyProps {
   operationId: String
   driverId: String
   riderId: String
-  driverPosition: String
+  driverPosition: driverPosition
   isDrop: Boolean
 }
 
 export const driverStateNotify = async (client: any, driverState: driverStateNotifyProps) => {
-  const { data } = await client.mutate({
-    mutation: driverStateNotifyQuery,
-    variables: driverState,
-    fetchPolicy: 'no-cache',
-  });
+  try {
+    const { data } = await client.mutate({
+      mutation: driverStateNotifyQuery,
+      variables: driverState,
+      fetchPolicy: 'no-cache',
+    });
+  } catch (error) {
+  }
 };

--- a/client/src/apis/driverAPI.tsx
+++ b/client/src/apis/driverAPI.tsx
@@ -1,5 +1,7 @@
 import { driverStateNotifyQuery } from '../queries/driver';
 
+import { ApolloClient } from '@apollo/client';
+
 interface driverPosition {
   lat: number
   lng: number
@@ -13,7 +15,7 @@ interface driverStateNotifyProps {
   isDrop: Boolean
 }
 
-export const driverStateNotify = async (client: any, driverState: driverStateNotifyProps) => {
+export const driverStateNotify = async (client: ApolloClient<Object>, driverState: driverStateNotifyProps) => {
   try {
     const { data } = await client.mutate({
       mutation: driverStateNotifyQuery,

--- a/client/src/apis/driverAPI.tsx
+++ b/client/src/apis/driverAPI.tsx
@@ -6,7 +6,7 @@ interface driverPosition {
 }
 
 interface driverStateNotifyProps {
-  operationId: String
+  tripId: String
   driverId: String
   riderId: String
   driverPosition: driverPosition

--- a/client/src/components/containers/DriverPickUpForm.tsx
+++ b/client/src/components/containers/DriverPickUpForm.tsx
@@ -45,7 +45,7 @@ export default function DriverPickUpForm() {
 
   useEffect(() => {
     const driverState = {
-      operationId: '1',
+      tripId: '1',
       driverId: 'driver@test.com',
       riderId: 'rider@test.com',
       driverPosition: driverPos,

--- a/client/src/components/containers/DriverPickUpForm.tsx
+++ b/client/src/components/containers/DriverPickUpForm.tsx
@@ -1,0 +1,72 @@
+import React, { useState, useEffect } from 'react';
+
+import { useApolloClient } from '@apollo/client';
+
+import { driverStateNotify } from '../../apis/driverAPI';
+
+import PickUpMap from '../containers/PickUpMap';
+import RiderInfoBox from '../containers/RiderInfoBox';
+
+const INIT_POS = {
+  lat: 34.047,
+  lng: -118.249,
+};
+
+export default function DriverPickUpForm() {
+  const client = useApolloClient();
+  const [driverPos, setDriverPos] = useState(INIT_POS);
+
+  const success = (position: Position): any => {
+    const pos = {
+      lat: position.coords.latitude,
+      lng: position.coords.longitude,
+    };
+    setDriverPos(pos);
+  };
+
+  const navError = (): any => {
+    console.log('Error: The Geolocation service failed.');
+  };
+
+  const options = {
+    enableHighAccuracy: false,
+    maximumAge: 0,
+  };
+
+  const getDriverPosition = () => {
+    if (navigator.geolocation) {
+      navigator.geolocation.watchPosition(success, navError, options);
+    }
+  };
+
+  useEffect(() => {
+    getDriverPosition();
+  }, []);
+
+  useEffect(() => {
+    const driverState = {
+      operationId: '1',
+      driverId: 'driver@test.com',
+      riderId: 'rider@test.com',
+      driverPosition: driverPos,
+      isDrop: false,
+    };
+    driverStateNotify(client, driverState);
+  }, [driverPos]);
+
+  return (
+    <>
+      <PickUpMap
+        isRider={false}
+        riderLat={35.6895}
+        riderLng={139.691706}
+        driverLat={driverPos.lat}
+        driverLng={driverPos.lng}
+        pickUpLat={35.689487}
+        pickUpLng={139.691706}
+      />
+      <RiderInfoBox />
+    </>
+  );
+}
+

--- a/client/src/components/containers/PickUpMap.tsx
+++ b/client/src/components/containers/PickUpMap.tsx
@@ -11,7 +11,7 @@ const containerStyle = {
   height: '75vh',
 };
 
-export default function PickUpMap({ isRider, riderLat, riderLng, driverLat, driverLng, pickUpLat, pickUpLng }: {isRider: Boolean, riderLat: number, riderLng: number, driverLat: number, driverLng: number, pickUpLat: number, pickUpLng: number}) {
+export default function PickUpMap({ isRider, riderLat, riderLng, driverLat, driverLng, pickUpLat, pickUpLng }: {isRider: boolean, riderLat: number, riderLng: number, driverLat: number, driverLng: number, pickUpLat: number, pickUpLng: number}) {
   const [driverPos, setDriverPos] = useState({
     lat: driverLat,
     lng: driverLng,

--- a/client/src/components/containers/PickUpMap.tsx
+++ b/client/src/components/containers/PickUpMap.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { GoogleMap, OverlayView } from '@react-google-maps/api';
 
@@ -11,74 +11,46 @@ const containerStyle = {
   height: '75vh',
 };
 
-const INIT_POS = {
-  lat: 34.040,
-  lng: -118.246,
-};
-
-const INIT_DRIVER_POS = {
-  lat: 34.047,
-  lng: -118.249,
-};
-
-const INIT_PICKUP_POS = {
-  lat: 34.040,
-  lng: -118.246,
-};
-
-function PickUpMap({ isRider }:{isRider:boolean}) {
-  const [map, setMap] = useState(null);
-  const [center, setCenter] = useState(INIT_POS);
-  const [driverPos, setDriverPos] = useState(INIT_DRIVER_POS);
-  const [pickUpPos, setPickUpPos] = useState(INIT_PICKUP_POS);
-
-  const onLoad = useCallback((map) => {
-    setMap(map);
-  }, []);
-
-  const onUnmount = useCallback(() => {
-    setMap(null);
-  }, []);
-
-  const success = (position: Position): any => {
-    const pos = {
-      lat: position.coords.latitude,
-      lng: position.coords.longitude,
-    };
-    if (JSON.stringify(center) !== JSON.stringify(pos)) {
-      setCenter(pos);
-      if (!isRider) {
-        setDriverPos(pos);
-      };
-    }
-  };
-
-  const error = (): any => {
-    console.log('Error: The Geolocation service failed.');
-  };
-
-  const options = {
-    enableHighAccuracy: false,
-    maximumAge: 0,
-  };
-
-  const getUserPosition = () => {
-    if (navigator.geolocation) {
-      navigator.geolocation.watchPosition(success, error, options);
-    }
-  };
+export default function PickUpMap({ isRider, riderLat, riderLng, driverLat, driverLng, pickUpLat, pickUpLng }: {isRider: Boolean, riderLat: number, riderLng: number, driverLat: number, driverLng: number, pickUpLat: number, pickUpLng: number}) {
+  const [driverPos, setDriverPos] = useState({
+    lat: driverLat,
+    lng: driverLng,
+  });
+  const [pickUpPos, setPickUpPos] = useState({
+    lat: pickUpLat,
+    lng: pickUpLng,
+  });
+  const [riderPos, setRiderPos] = useState({
+    lat: riderLat,
+    lng: riderLng,
+  });
 
   useEffect(() => {
-    getUserPosition();
-  }, []);
+    setDriverPos({
+      lat: driverLat,
+      lng: driverLng,
+    });
+  }, [driverLat]);
+
+  useEffect(() => {
+    setRiderPos({
+      lat: riderLat,
+      lng: riderLng,
+    });
+  }, [riderLat]);
+
+  useEffect(() => {
+    setPickUpPos({
+      lat: pickUpLat,
+      lng: pickUpLng,
+    });
+  }, [pickUpLat]);
 
   return (
     <GoogleMap
       mapContainerStyle={containerStyle}
       zoom={16}
-      onLoad={onLoad}
-      onUnmount={onUnmount}
-      center={center}
+      center={isRider ? riderPos : driverPos}
     >
       <OverlayView
         position={driverPos}
@@ -92,14 +64,12 @@ function PickUpMap({ isRider }:{isRider:boolean}) {
       >
         <PinIcon />
       </OverlayView>
-      {isRider && <OverlayView
-        position={center}
+      <OverlayView
+        position={riderPos}
         mapPaneName={OverlayView.OVERLAY_MOUSE_TARGET}
       >
         <CurrentLocationIcon />
-      </OverlayView>}
+      </OverlayView>
     </GoogleMap>
   );
 }
-
-export default PickUpMap;

--- a/client/src/components/containers/RiderPickUpForm.tsx
+++ b/client/src/components/containers/RiderPickUpForm.tsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from 'react';
+
+import { useSubscription } from '@apollo/client';
+
+import { matchedDriverState } from '../../queries/rider';
+
+import PickUpMap from '../containers/PickUpMap';
+import DriverInfoBox from '../containers/DriverInfoBox';
+
+const INIT_POS = {
+  lat: 34.047,
+  lng: -118.249,
+};
+
+export default function RiderPickUpForm() {
+  const { loading, error, data } = useSubscription(matchedDriverState);
+  const [riderPos, setRiderPos] = useState(INIT_POS);
+
+  const success = (position: Position): any => {
+    const pos = {
+      lat: position.coords.latitude,
+      lng: position.coords.longitude,
+    };
+    setRiderPos(pos);
+  };
+
+  const navError = (): any => {
+    console.log('Error: The Geolocation service failed.');
+  };
+
+  const options = {
+    enableHighAccuracy: false,
+    maximumAge: 0,
+  };
+
+  const getDriverPosition = () => {
+    if (navigator.geolocation) {
+      navigator.geolocation.watchPosition(success, navError, options);
+    }
+  };
+
+  useEffect(() => {
+    getDriverPosition();
+  }, []);
+
+  if (error) {
+    return <p>error</p>;
+  }
+  if (loading) {
+    return <p>드라이버 위치정보를 불러오는 중입니다</p>;
+  }
+  return (
+    <>
+      <PickUpMap
+        isRider={true}
+        riderLat={riderPos.lat}
+        riderLng={riderPos.lng}
+        driverLat={data.matchedDriverState.driverPosition.lat}
+        driverLng={data.matchedDriverState.driverPosition.lng}
+        pickUpLat={35.689487}
+        pickUpLng={139.691706}
+      />
+      <DriverInfoBox />
+    </>
+  );
+}
+

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -26,6 +26,9 @@ const wsLink = new WebSocketLink({
   uri: process.env.REACT_APP_WEBSOCKET_URI,
   options: {
     reconnect: true,
+    connectionParams: {
+      Authorization: 'Bearer ' + localStorage.getItem('token'),
+    },
   },
 });
 
@@ -47,7 +50,7 @@ const splitLink = split(
       definition.operation === 'subscription'
     );
   },
-  authLink.concat(wsLink),
+  wsLink,
   authLink.concat(httpLink),
 );
 

--- a/client/src/pages/DriverPickUpPage.tsx
+++ b/client/src/pages/DriverPickUpPage.tsx
@@ -4,14 +4,12 @@ import { LoadScript } from '@react-google-maps/api';
 import { Libraries } from '@react-google-maps/api/dist/utils/make-load-script-url';
 const libraries: Libraries = ['places'];
 
-import PickUpMap from '../components/containers/PickUpMap';
-import RiderInfoBox from '../components/containers/RiderInfoBox';
+import DriverPickUpForm from '../components/containers/DriverPickUpForm';
 
 function DriverPickUpPage() {
   return (
     <LoadScript googleMapsApiKey={process.env.REACT_APP_API_KEY} libraries={libraries}>
-      <PickUpMap isRider={false}/>
-      <RiderInfoBox />
+      <DriverPickUpForm />
     </LoadScript>
   );
 }

--- a/client/src/pages/DriverPickUpPage.tsx
+++ b/client/src/pages/DriverPickUpPage.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 
 import { LoadScript } from '@react-google-maps/api';
-import { Libraries } from '@react-google-maps/api/dist/utils/make-load-script-url';
-const libraries: Libraries = ['places'];
 
 import DriverPickUpForm from '../components/containers/DriverPickUpForm';
 
 function DriverPickUpPage() {
   return (
-    <LoadScript googleMapsApiKey={process.env.REACT_APP_API_KEY} libraries={libraries}>
+    <LoadScript googleMapsApiKey={process.env.REACT_APP_API_KEY}>
       <DriverPickUpForm />
     </LoadScript>
   );

--- a/client/src/pages/RiderPickUpPage.tsx
+++ b/client/src/pages/RiderPickUpPage.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 
 import { LoadScript } from '@react-google-maps/api';
-import { Libraries } from '@react-google-maps/api/dist/utils/make-load-script-url';
-const libraries: Libraries = ['places'];
 
 import RiderPickUpForm from '../components/containers/RiderPickUpForm';
 
 function RiderPickUpPage() {
   return (
-    <LoadScript googleMapsApiKey={process.env.REACT_APP_API_KEY} libraries={libraries}>
+    <LoadScript googleMapsApiKey={process.env.REACT_APP_API_KEY}>
       <RiderPickUpForm />
     </LoadScript>
   );

--- a/client/src/pages/RiderPickUpPage.tsx
+++ b/client/src/pages/RiderPickUpPage.tsx
@@ -4,14 +4,12 @@ import { LoadScript } from '@react-google-maps/api';
 import { Libraries } from '@react-google-maps/api/dist/utils/make-load-script-url';
 const libraries: Libraries = ['places'];
 
-import PickUpMap from '../components/containers/PickUpMap';
-import DriverInfoBox from '../components/containers/DriverInfoBox';
+import RiderPickUpForm from '../components/containers/RiderPickUpForm';
 
 function RiderPickUpPage() {
   return (
     <LoadScript googleMapsApiKey={process.env.REACT_APP_API_KEY} libraries={libraries}>
-      <PickUpMap isRider={true}/>
-      <DriverInfoBox />
+      <RiderPickUpForm />
     </LoadScript>
   );
 }

--- a/client/src/queries/driver.ts
+++ b/client/src/queries/driver.ts
@@ -1,25 +1,27 @@
 import { gql } from '@apollo/client';
 
 export const driverStateNotifyQuery = gql`
-  mutation driverStateNotify(
-    $operationId: String
-    $driverId: String
-    $riderId: String
-    $driverPosition: String
-    $isDrop: Boolean
-    ){
-    loginRider(
-      operationId:$operationId,
-      driverId:$driverId
-      riderId:$riderId
-      driverPosition:$driverPosition
-      isDrop:$isDrop
+mutation driverStateNotify(
+  $operationId:String,
+  $driverId:String,
+  $riderId:String,
+  $driverPosition:DriverPositionInput,
+  $isDrop:Boolean){
+      driverStateNotify(
+        operationId:$operationId,
+        driverId:$driverId,
+        riderId:$riderId,
+        driverPosition:$driverPosition,
+        isDrop:$isDrop
       ){
-      operationId
-      driverId
-      riderId
-      driverPosition
-      isDrop
+        operationId
+        driverId
+        riderId
+        isDrop
+        driverPosition {
+          lat
+          lng
+        }
+      }
     }
-  }
 `;

--- a/client/src/queries/driver.ts
+++ b/client/src/queries/driver.ts
@@ -7,21 +7,21 @@ mutation driverStateNotify(
   $riderId:String,
   $driverPosition:DriverPositionInput,
   $isDrop:Boolean){
-      driverStateNotify(
-        tripId:$tripId,
-        driverId:$driverId,
-        riderId:$riderId,
-        driverPosition:$driverPosition,
-        isDrop:$isDrop
-      ){
-        tripId
-        driverId
-        riderId
-        isDrop
-        driverPosition {
-          lat
-          lng
-        }
+    driverStateNotify(
+      tripId:$tripId,
+      driverId:$driverId,
+      riderId:$riderId,
+      driverPosition:$driverPosition,
+      isDrop:$isDrop
+    ){
+      tripId
+      driverId
+      riderId
+      isDrop
+      driverPosition {
+        lat
+        lng
       }
     }
+  }
 `;

--- a/client/src/queries/driver.ts
+++ b/client/src/queries/driver.ts
@@ -2,19 +2,19 @@ import { gql } from '@apollo/client';
 
 export const driverStateNotifyQuery = gql`
 mutation driverStateNotify(
-  $operationId:String,
+  $tripId:String,
   $driverId:String,
   $riderId:String,
   $driverPosition:DriverPositionInput,
   $isDrop:Boolean){
       driverStateNotify(
-        operationId:$operationId,
+        tripId:$tripId,
         driverId:$driverId,
         riderId:$riderId,
         driverPosition:$driverPosition,
         isDrop:$isDrop
       ){
-        operationId
+        tripId
         driverId
         riderId
         isDrop

--- a/client/src/queries/driver.ts
+++ b/client/src/queries/driver.ts
@@ -1,0 +1,25 @@
+import { gql } from '@apollo/client';
+
+export const driverStateNotifyQuery = gql`
+  mutation driverStateNotify(
+    $operationId: String
+    $driverId: String
+    $riderId: String
+    $driverPosition: String
+    $isDrop: Boolean
+    ){
+    loginRider(
+      operationId:$operationId,
+      driverId:$driverId
+      riderId:$riderId
+      driverPosition:$driverPosition
+      isDrop:$isDrop
+      ){
+      operationId
+      driverId
+      riderId
+      driverPosition
+      isDrop
+    }
+  }
+`;

--- a/client/src/queries/rider.ts
+++ b/client/src/queries/rider.ts
@@ -6,8 +6,11 @@ export const matchedDriverState = gql`
 	    operationId
 	    driverId
 	    riderId
-	    driverPosition
 	    isDrop
+	    driverPosition {
+				lat
+				lng
+			}
 	  }
 	}
 `;

--- a/client/src/queries/rider.ts
+++ b/client/src/queries/rider.ts
@@ -3,7 +3,7 @@ import { gql } from '@apollo/client';
 export const matchedDriverState = gql`
 	subscription {
 		matchedDriverState { 
-	    operationId
+	    tripId
 	    driverId
 	    riderId
 	    isDrop

--- a/client/src/queries/rider.ts
+++ b/client/src/queries/rider.ts
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+
+export const matchedDriverState = gql`
+	subscription {
+		matchedDriverState { 
+	    operationId
+	    driverId
+	    riderId
+	    driverPosition
+	    isDrop
+	  }
+	}
+`;

--- a/client/src/routes/RouteIf.tsx
+++ b/client/src/routes/RouteIf.tsx
@@ -16,6 +16,9 @@ import DriverPickUpPage from '../pages/DriverPickUpPage';
 import LoginPage from '../pages/LoginPage';
 import RiderPickUpPage from '../pages/RiderPickUpPage';
 
+import RiderPickUpForm from '../components/containers/RiderPickUpForm';
+import DriverPickUpForm from '../components/containers/DriverPickUpForm';
+
 interface Paths {
   path: string;
 }
@@ -45,8 +48,8 @@ const RouteIf: FunctionComponent<Paths> = ({ path }) => {
         if (loginReducer.loginRole === 'rider') {
           return (
             <Switch>
-              <Route path='/setcourse' component={SetCoursePage} />
-              <Route path='/pickup' component={RiderPickUpPage} />
+              <Route path='/rider/setcourse' component={SetCoursePage} />
+              <Route path='/rider/pickup' component={RiderPickUpPage} />
               <Redirect path="*" to="/setcourse" />
             </Switch>
           );

--- a/client/src/routes/RouteIf.tsx
+++ b/client/src/routes/RouteIf.tsx
@@ -16,9 +16,6 @@ import DriverPickUpPage from '../pages/DriverPickUpPage';
 import LoginPage from '../pages/LoginPage';
 import RiderPickUpPage from '../pages/RiderPickUpPage';
 
-import RiderPickUpForm from '../components/containers/RiderPickUpForm';
-import DriverPickUpForm from '../components/containers/DriverPickUpForm';
-
 interface Paths {
   path: string;
 }

--- a/client/src/routes/RouteIf.tsx
+++ b/client/src/routes/RouteIf.tsx
@@ -50,7 +50,7 @@ const RouteIf: FunctionComponent<Paths> = ({ path }) => {
             <Switch>
               <Route path='/rider/setcourse' component={SetCoursePage} />
               <Route path='/rider/pickup' component={RiderPickUpPage} />
-              <Redirect path="*" to="/setcourse" />
+              <Redirect path="*" to="/rider/setcourse" />
             </Switch>
           );
         }

--- a/server/src/graphql/resolvers/driver.ts
+++ b/server/src/graphql/resolvers/driver.ts
@@ -47,8 +47,9 @@ export default {
       pubsub.publish('driverListen', { driverListen: args });
       return await args;
     },
-    async driverStateNotify(_, args) {
+    driverStateNotify(_, args) {
       pubsub.publish(MATCHED_DRIVER_STATE, { matchedDriverState: args });
+      return args;
     },
   },
   Subscription: {

--- a/server/src/graphql/resolvers/driver.ts
+++ b/server/src/graphql/resolvers/driver.ts
@@ -25,6 +25,8 @@ interface DriverCallArgs {
 
 const pubsub = new PubSub();
 
+const MATCHED_DRIVER_STATE = 'MATCHED_DRIVER_STATE';
+
 export default {
   Query: {
     async driver(parent: any, args: { email: string }, context: any, info: any) {
@@ -35,20 +37,26 @@ export default {
     },
   },
   Mutation: {
-    async createDriver(parent: any, args: createDriverArgs, context: any, info: any) {
+    async createDriver(_, args: createDriverArgs) {
       return await Driver.signup(args);
     },
     async loginDriver(_: any, payload:LoginPayload, context) {
       return await Driver.login(context, payload);
     },
-    async driverCall(root, args : DriverCallArgs, context) {
-      pubsub.publish("driverListen", { driverListen: args });
+    async driverCall(_, args : DriverCallArgs) {
+      pubsub.publish('driverListen', { driverListen: args });
       return await args;
+    },
+    async driverStateNotify(_, args) {
+      pubsub.publish(MATCHED_DRIVER_STATE, { matchedDriverState: args });
     },
   },
   Subscription: {
     driverListen: {
-      subscribe: () => pubsub.asyncIterator(["driverListen"]),
+      subscribe: () => pubsub.asyncIterator(['driverListen']),
+    },
+    matchedDriverState: {
+      subscribe: () => pubsub.asyncIterator([MATCHED_DRIVER_STATE]),
     },
   },
 };

--- a/server/src/graphql/types/driver.graphql
+++ b/server/src/graphql/types/driver.graphql
@@ -24,11 +24,21 @@ type driverCall  {
   destination: String
 }
 
+input DriverPositionInput {
+  lat: Float
+  lng: Float
+}
+
+type DriverPosition {
+  lat: Float
+  lng: Float
+}
+
 type driverStateNotify {
   operationId: String
   driverId: String
   riderId: String
-  driverPosition: String
+  driverPosition: DriverPosition
   isDrop: Boolean
 }
 
@@ -63,7 +73,7 @@ type Mutation {
     operationId: String
     driverId: String
     riderId: String
-    driverPosition: String
+    driverPosition: DriverPositionInput
     isDrop: Boolean
   ): driverStateNotify
 }

--- a/server/src/graphql/types/driver.graphql
+++ b/server/src/graphql/types/driver.graphql
@@ -17,15 +17,25 @@ type LoginResult {
   role: String!
   token: String
 }
+
 type driverCall  {
   riderId: String
   origin: String
   destination: String
 }
 
+type driverStateNotify {
+  operationId: String
+  driverId: String
+  riderId: String
+  driverPosition: String
+  isDrop: Boolean
+}
+
 type Query {
   driver(email: String!): Driver
 }
+
 type Mutation {
   createDriver(
     email: String!,
@@ -37,10 +47,28 @@ type Mutation {
     description: String,
     profileImage: String
   ): Driver
-  loginDriver(email: String!, password: String!): LoginResult
-  driverCall(riderId: String, origin: String, destination: String): driverCall
+  
+  loginDriver(
+    email: String!,
+    password: String!
+  ): LoginResult
+  
+  driverCall(
+    riderId: String,
+    origin: String,
+    destination: String
+  ): driverCall
+  
+  driverStateNotify(
+    operationId: String
+    driverId: String
+    riderId: String
+    driverPosition: String
+    isDrop: Boolean
+  ): driverStateNotify
 }
 
 type Subscription {
   driverListen: driverCall
+  matchedDriverState: driverStateNotify
 }

--- a/server/src/graphql/types/driver.graphql
+++ b/server/src/graphql/types/driver.graphql
@@ -35,7 +35,7 @@ type DriverPosition {
 }
 
 type driverStateNotify {
-  operationId: String
+  tripId: String
   driverId: String
   riderId: String
   driverPosition: DriverPosition
@@ -70,7 +70,7 @@ type Mutation {
   ): driverCall
   
   driverStateNotify(
-    operationId: String
+    tripId: String
     driverId: String
     riderId: String
     driverPosition: DriverPositionInput


### PR DESCRIPTION
## 개요

- 라이더가 드라이버의 현재위치를 실시간으로 받아 화면에 보여줘야한다.

## 작업사항

- matchedDriverState를 sub하는 rider와 pub하는 driver를 구현했습니다.
- 드라이버와 라이더의 pickup페이지에 각각 서로의 위치정보가 실시간으로 반영되도록 했습니다.

## 기타

> 라이더화면입니다. (드라이버의 정보를 실시간으로 받아서 화면에 보여주는 장면입니다)
![ezgif com-gif-maker](https://user-images.githubusercontent.com/52442237/100892809-1135ad00-34fe-11eb-9c38-1bff5799e169.gif)
