### PR TITLE
로그인/회원가입 useMutation 사용하도록 변경

### DIFF
--- a/client/src/components/containers/DriverSignUpFrom.tsx
+++ b/client/src/components/containers/DriverSignUpFrom.tsx
@@ -5,14 +5,14 @@ import styled from 'styled-components';
 
 import { WhiteSpace } from 'antd-mobile';
 
-import { useApolloClient } from '@apollo/client';
+import { useMutation } from '@apollo/client';
 
 import ProfileImageInput from '../presentational/ProfileImageInput';
 import Input from '../presentational/Input';
 import DiscriptionInput from '../presentational/DescriptionInput';
 import SubmitButton from '../presentational/SubmitButton';
 
-import { requestDriverSignUp } from '../../apis/signUpAPI';
+import { SIGNUP_DRIVER } from '../../queries/signup';
 
 import { checkValidation } from '../../utils/validate';
 
@@ -21,8 +21,8 @@ const Form = styled.form`
 `;
 
 function DriverSignUpFrom() {
-  const client = useApolloClient();
   const history = useHistory();
+  const [signUpDriver] = useMutation(SIGNUP_DRIVER);
 
   const [name, setName] = useState('');
   const [phoneNumber, setPhoneNumber] = useState('');
@@ -37,9 +37,15 @@ function DriverSignUpFrom() {
     setState(value);
   };
 
-  const handleSignUpButton = () => {
+  const handleSignUpButton = async () => {
     const driverInfo = { name, phoneNumber, email, password, carType, plateNumber };
-    requestDriverSignUp(client, history, driverInfo);
+    try {
+      await signUpDriver({ variables: driverInfo });
+      window.alert('회원가입 성공');
+      history.push('/login');
+    } catch (error) {
+      window.alert('회웝가입 실패');
+    }
   };
 
   const propertyToCheck = { name, phoneNumber, email, password, rePassword, carType, plateNumber };

--- a/client/src/components/containers/DriverSignUpFrom.tsx
+++ b/client/src/components/containers/DriverSignUpFrom.tsx
@@ -44,7 +44,7 @@ function DriverSignUpFrom() {
       window.alert('회원가입 성공');
       history.push('/login');
     } catch (error) {
-      window.alert('회웝가입 실패');
+      window.alert(`회원가입 실패\n원인${error}`);
     }
   };
 

--- a/client/src/components/containers/LoginForm.tsx
+++ b/client/src/components/containers/LoginForm.tsx
@@ -2,13 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
-import { useApolloClient } from '@apollo/client';
+import { useMutation } from '@apollo/client';
 
 import { WhiteSpace, Checkbox, List, Switch } from 'antd-mobile';
 
 import styled from 'styled-components';
 
-import { requestLogin } from '../../apis/loginAPI';
+import { LOGIN_RIDER, LOGIN_DRIVER } from '../../queries/login';
+import { setLoginRole } from '../../slices/loginSlice';
 
 import { checkValidation } from '../../utils/validate';
 
@@ -50,9 +51,38 @@ const SignupButton = styled.button`
 `;
 
 function LoginForm() {
-  const client = useApolloClient();
   const history = useHistory();
   const dispatch = useDispatch();
+  const [loginRider, { data: riderData, error: riderError }] = useMutation(
+    LOGIN_RIDER,
+    {
+      onCompleted: ({ loginRider }) => {
+        const { message, role, success, token } = loginRider;
+        if (success) {
+          localStorage.setItem('token', token);
+          dispatch(setLoginRole(role));
+          history.push('/setcourse');
+        } else {
+          window.alert(message);
+        }
+      },
+    },
+  );
+  const [loginDriver, { data: driverData, error: driverError }] = useMutation(
+    LOGIN_DRIVER,
+    {
+      onCompleted: ({ loginDriver }) => {
+        const { message, role, success, token } = loginDriver;
+        if (success) {
+          localStorage.setItem('token', token);
+          dispatch(setLoginRole(role));
+          history.push('/setcourse');
+        } else {
+          window.alert(message);
+        }
+      },
+    },
+  );
 
   const [riderCheck, setRiderCheck] = useState(true);
   const [driverCheck, setDriverCheck] = useState(false);
@@ -64,8 +94,10 @@ function LoginForm() {
     setState(value);
   };
 
-  const handleLoginButtonClick = () => {
-    requestLogin(client, history, riderCheck, email, password, dispatch);
+  const handleLoginButtonClick = async () => {
+    riderCheck
+      ? await loginRider({ variables: { email, password } })
+      : await loginDriver({ variables: { email, password } });
   };
 
   const checkToggle = (e: any) => {
@@ -88,6 +120,7 @@ function LoginForm() {
 
   return (
     <Div>
+      {riderError && <p>try again</p>}
       <Header>UBER</Header>
       <CheckContent>
         <Checkbox

--- a/client/src/components/containers/LoginForm.tsx
+++ b/client/src/components/containers/LoginForm.tsx
@@ -61,7 +61,7 @@ function LoginForm() {
         if (success) {
           localStorage.setItem('token', token);
           dispatch(setLoginRole(role));
-          history.push('/setcourse');
+          history.push('/rider/setcourse');
         } else {
           window.alert(message);
         }
@@ -76,7 +76,7 @@ function LoginForm() {
         if (success) {
           localStorage.setItem('token', token);
           dispatch(setLoginRole(role));
-          history.push('/setcourse');
+          history.push('/driver/main');
         } else {
           window.alert(message);
         }

--- a/client/src/components/containers/RiderSignUpForm.tsx
+++ b/client/src/components/containers/RiderSignUpForm.tsx
@@ -20,7 +20,7 @@ const Form = styled.form`
 `;
 
 function RiderSignUpForm() {
-  const [signUpRider, { data }] = useMutation(SIGNUP_RIDER);
+  const [signUpRider] = useMutation(SIGNUP_RIDER);
   const history = useHistory();
 
   const [name, setName] = useState('');
@@ -36,11 +36,11 @@ function RiderSignUpForm() {
 
   const handleSignUpButton = async () => {
     const riderInfo = { name, phoneNumber, email, password };
-    await signUpRider({ variables: riderInfo });
-    if (data) {
+    try {
+      await signUpRider({ variables: riderInfo });
       window.alert('회원가입 성공');
       history.push('/login');
-    } else {
+    } catch (error) {
       window.alert('회원가입 실패');
     }
   };

--- a/client/src/components/containers/RiderSignUpForm.tsx
+++ b/client/src/components/containers/RiderSignUpForm.tsx
@@ -41,7 +41,7 @@ function RiderSignUpForm() {
       window.alert('회원가입 성공');
       history.push('/login');
     } catch (error) {
-      window.alert('회원가입 실패');
+      window.alert(`회원가입 실패\n원인${error}`);
     }
   };
 

--- a/client/src/components/containers/RiderSignUpForm.tsx
+++ b/client/src/components/containers/RiderSignUpForm.tsx
@@ -5,12 +5,12 @@ import styled from 'styled-components';
 
 import { WhiteSpace } from 'antd-mobile';
 
-import { useApolloClient } from '@apollo/client';
+import { useMutation } from '@apollo/client';
 
 import SubmitButton from '../presentational/SubmitButton';
 import Input from '../presentational/Input';
 
-import { requestRiderSignUp } from '../../apis/signUpAPI';
+import { SIGNUP_RIDER } from '../../queries/signup';
 
 import { checkValidation } from '../../utils/validate';
 
@@ -20,7 +20,7 @@ const Form = styled.form`
 `;
 
 function RiderSignUpForm() {
-  const client = useApolloClient();
+  const [signUpRider, { data }] = useMutation(SIGNUP_RIDER);
   const history = useHistory();
 
   const [name, setName] = useState('');
@@ -34,9 +34,15 @@ function RiderSignUpForm() {
     setState(value);
   };
 
-  const handleSignUpButton = () => {
+  const handleSignUpButton = async () => {
     const riderInfo = { name, phoneNumber, email, password };
-    requestRiderSignUp(client, history, riderInfo);
+    await signUpRider({ variables: riderInfo });
+    if (data) {
+      window.alert('회원가입 성공');
+      history.push('/login');
+    } else {
+      window.alert('회원가입 실패');
+    }
   };
 
   const propertyToCheck = { name, phoneNumber, email, password, rePassword };

--- a/client/src/queries/login.ts
+++ b/client/src/queries/login.ts
@@ -1,23 +1,26 @@
 import { gql } from '@apollo/client';
 
-export const loginRiderQuery = gql`mutation loginQuery($email:String!,$password:String!){
-  loginRider(email:$email,password:$password){
-    success
-    name
-    token
-    message
-    role
+export const LOGIN_RIDER = gql`
+  mutation loginQuery($email:String!,$password:String!){
+    loginRider(email:$email,password:$password){
+      success
+      name
+      token
+      message
+      role
+    }
   }
-}`;
+`;
 
-export const loginDriverQuery = gql`mutation loginQuery($email:String!,$password:String!){
-  loginDriver(email:$email,password:$password){
-    success
-    name
-    token
-    message
-    role
+export const LOGIN_DRIVER = gql`
+  mutation loginQuery($email:String!,$password:String!){
+    loginDriver(email:$email,password:$password){
+      success
+      name
+      token
+      message
+      role
+    }
   }
-}
 `;
 

--- a/client/src/queries/signup.ts
+++ b/client/src/queries/signup.ts
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client';
 
-export const signUpDriver = gql`
+export const SIGNUP_DRIVER = gql`
   mutation signupQuery(
     $email:String!,
     $name:String!,
@@ -26,8 +26,8 @@ export const signUpDriver = gql`
   }
 `;
 
-export const signUpRider = gql`
-  mutation signupQuery(    
+export const SIGNUP_RIDER = gql`
+  mutation signupMutation(    
     $email:String!,
     $name:String!,
     $password:String!,


### PR DESCRIPTION
## 개요

- RESTful API처럼 Apollo Client를 사용하는 것을 Apollo Client에서 제공하는 API Hook을 이용하도록 변경

## 작업사항

- mutation 변수명 변경
- signUpDriver에 useMutation 사용하도록 변경
- signUpRider에 useMutation 사용하도록 변경
- loginForm에서 useMutation 사용하도록 변경

## 기타

- useMutation 또는 useQuery 사용할 때 onComplete callback method를 사용하는게 좋은 방법인지 모르겠습니다.
- role을 서버에서 받아오기보다 client에만 존재하는 field로 cache 사용하는것이 어떨까요?