### PR TITLE
페이지 라우팅, 캐시 업데이트

### DIFF
--- a/client/src/components/containers/DriverInfoBox.tsx
+++ b/client/src/components/containers/DriverInfoBox.tsx
@@ -93,7 +93,7 @@ function DriverInfoBox() {
 
   useEffect(() => {
     if (data && data.cancelTrip.result === 'canceled') {
-      dispatch(setTrip({ id: '' }));
+      dispatch(setTrip({ id: undefined }));
       notifyRiderState({ variables: { tripId: trip.id, isCancel: true } });
       alert('호출 취소', '취소 되었습니다.', [
         { text: 'OK', onPress: () => history.push('/rider/setcourse') },

--- a/client/src/components/containers/DriverInfoBox.tsx
+++ b/client/src/components/containers/DriverInfoBox.tsx
@@ -94,7 +94,7 @@ function DriverInfoBox() {
   useEffect(() => {
     if (data && data.cancelTrip.result === 'canceled') {
       dispatch(setTrip({ id: undefined }));
-      notifyRiderState({ variables: { tripId: trip.id, isCancel: true } });
+      notifyRiderState({ variables: { tripId: trip.id } });
       alert('호출 취소', '취소 되었습니다.', [
         { text: 'OK', onPress: () => history.push('/rider/setcourse') },
       ]);

--- a/client/src/components/containers/DriverPickUpForm.tsx
+++ b/client/src/components/containers/DriverPickUpForm.tsx
@@ -109,7 +109,7 @@ export default function DriverPickUpForm() {
         pickUpLat={originPosition.lat}
         pickUpLng={originPosition.lng}
       />
-      <RiderInfoBox onBoard={false}/>
+      <RiderInfoBox onBoard={false} currentPos={driverPos}/>
     </>
   );
 }

--- a/client/src/components/containers/DriverPickUpForm.tsx
+++ b/client/src/components/containers/DriverPickUpForm.tsx
@@ -79,14 +79,14 @@ export default function DriverPickUpForm() {
   }, [count]);
 
   useEffect(() => {
-    notifyDriverState({ variables: { tripId: trip.id, driverPosition: driverPos, isDrop: false } });
+    notifyDriverState({ variables: { tripId: trip.id, driverPosition: driverPos } });
   }, [driverPos]);
 
   useEffect(() => {
     if (data && data.matchedRiderState.latitude) {
       setRiderPos({ lat: data.matchedRiderState.latitude, lng: data.matchedRiderState.longitude });
     }
-    if (data && data.matchedRiderState.isCancel) {
+    if (data && data.matchedRiderState.trip.status === 'cancel') {
       alert('호출취소', '라이더가 호출을 취소하였습니다.', [{ text: 'OK', onPress: () => history.push('/driver/main') }]);
     }
   }, [data]);

--- a/client/src/components/containers/DrivingForm.tsx
+++ b/client/src/components/containers/DrivingForm.tsx
@@ -83,7 +83,7 @@ export default function DrivingForm({ isRider }:{isRider:boolean}) {
   }, [tripData]);
 
   useEffect(() => {
-    if (data && data.matchedDriverState.isDrop) {
+    if (data && data.matchedDriverState.trip.status === 'close') {
       history.push('/rider/tripend');
     }
   }, [data]);

--- a/client/src/components/containers/RiderInfoBox.tsx
+++ b/client/src/components/containers/RiderInfoBox.tsx
@@ -104,24 +104,24 @@ function RiderInfoBox({ onBoard, currentPos }:{onBoard:boolean, currentPos:{ lat
   };
 
   const handleOnClickDrop = () => {
-    const tripId = trip.id;
-    setTripStatus({ variables: { tripId, newTripStatus: 'close' } });
+    updateArrivalData();
   };
 
   useEffect(() => {
     if (data && data.setTripStatus.result === 'success') {
-      notifyDriverState({ variables: { tripId: trip.id, onBoard: true } });
+      notifyDriverState({ variables: { tripId: trip.id } });
       history.push('/driver/driving');
     }
     if (data && data.setTripStatus.result === 'close success') {
-      updateArrivalData();
+      notifyDriverState({ variables: { tripId: trip.id } });
+      history.push('/driver/tripend');
     }
   }, [data]);
 
   useEffect(() => {
     if (arrivalData) {
-      notifyDriverState({ variables: { tripId: trip.id, isDrop: true } });
-      history.push('/driver/tripend');
+      const tripId = trip.id;
+      setTripStatus({ variables: { tripId, newTripStatus: 'close' } });
     }
   }, [arrivalData]);
 
@@ -139,7 +139,7 @@ function RiderInfoBox({ onBoard, currentPos }:{onBoard:boolean, currentPos:{ lat
               <PlaceInfo>{ tripData?.trip.destination.address}</PlaceInfo>
             </div>
             <Buttons>
-              <DropButton onClick={handleOnClickDrop}>라이더 하차</DropButton>
+              <DropButton type={'button'} onClick={handleOnClickDrop}>라이더 하차</DropButton>
             </Buttons>
           </>
           :
@@ -149,7 +149,7 @@ function RiderInfoBox({ onBoard, currentPos }:{onBoard:boolean, currentPos:{ lat
               <PlaceInfo>{tripData?.trip.origin.address}</PlaceInfo>
             </div>
             <Buttons>
-              <PickUpButton onClick={handleOnClickBoardCompelete}>탑승완료</PickUpButton>
+              <PickUpButton type={'button'} onClick={handleOnClickBoardCompelete}>탑승완료</PickUpButton>
             </Buttons>
           </>
         }

--- a/client/src/components/containers/RiderPickUpForm.tsx
+++ b/client/src/components/containers/RiderPickUpForm.tsx
@@ -80,7 +80,7 @@ export default function RiderPickUpForm() {
     if (data && data.matchedDriverState.driverPosition) {
       setDriverPos(data.matchedDriverState.driverPosition);
     }
-    if (data && data.matchedDriverState.onBoard) {
+    if (data && data.matchedDriverState.trip.status === 'onBoard') {
       history.push('/rider/driving');
     }
   }, [data]);

--- a/client/src/components/containers/RiderPickupPositionMap.tsx
+++ b/client/src/components/containers/RiderPickupPositionMap.tsx
@@ -9,7 +9,7 @@ import { useHistory } from 'react-router-dom';
 import { LISTEN_DRIVER_RESPONSE } from '../../queries/driverResponded';
 import { GET_ORIGIN_POSITION_AND_DESTINATION_POSITION } from '../../queries/trip';
 import { setTrip } from '../../slices/tripSlice';
-import { MATCHING_CONFIRM } from '../../constants/matchingResult';
+import { MATCHED } from '../../constants/tripStatus';
 
 const containerStyle = {
   width: '100%',
@@ -40,9 +40,9 @@ function RiderPickupPositionMap() {
 
   useEffect(() => {
     if (data) {
-      const { response, driverId, tripId } = data.driverResponded;
-      if (response === MATCHING_CONFIRM) {
-        dispatch(setTrip({ id: tripId }));
+      const { id, status } = data.driverResponded;
+      if (status === MATCHED) {
+        dispatch(setTrip({ id }));
         history.push('/rider/pickup');
       }
     }

--- a/client/src/components/containers/RiderWaitingModal.tsx
+++ b/client/src/components/containers/RiderWaitingModal.tsx
@@ -86,7 +86,7 @@ function RiderWaitingForm() {
 
   useEffect(() => {
     if (data && data.cancelTrip.result === 'canceled') {
-      dispatch(setTrip({ id: '' }));
+      dispatch(setTrip({ id: undefined }));
       history.push('/rider/setcourse');
     }
   }, [data]);

--- a/client/src/components/containers/SetCourseForm.tsx
+++ b/client/src/components/containers/SetCourseForm.tsx
@@ -206,8 +206,8 @@ function SetCourseForm() {
   }, [destPlace]);
 
   useEffect(() => {
-    if (data) {
-      dispatch(setTrip({ id: data.driverCall }));
+    if (data && data.driverCall.result) {
+      dispatch(setTrip({ id: data.driverCall.trip.id }));
       history.push('/rider/waiting');
     }
   }, [data]);

--- a/client/src/components/presentational/DriverPopup.tsx
+++ b/client/src/components/presentational/DriverPopup.tsx
@@ -96,6 +96,9 @@ function DriverPopup({ trip, setDriverStatus }:
 
   const showAlert = (result:string) => {
     setStatus(result);
+    setTimeout(() => {
+      setDriverStatus(DRIVER_IGNORED);
+    }, 2000);
   };
 
   const handleClickIgnoreButton = () => {
@@ -104,10 +107,10 @@ function DriverPopup({ trip, setDriverStatus }:
 
   const handleClickSubmitButton = async() => {
     const { data } = await notifyDriverResponse();
-    if (data.sendResponse === MATCHING_SUCCESS) {
+    if (data.sendResponse.result === MATCHING_SUCCESS) {
       return setDriverStatus(DRIVER_MATCHING_SUCCESS);
     }
-    showAlert(data.sendResponse);
+    showAlert(data.sendResponse.trip.status);
   };
 
   useEffect(() => {

--- a/client/src/components/presentational/DriverPopup.tsx
+++ b/client/src/components/presentational/DriverPopup.tsx
@@ -105,8 +105,6 @@ function DriverPopup({ trip, setDriverStatus }:
   const handleClickSubmitButton = async() => {
     const { data } = await notifyDriverResponse();
     if (data.sendResponse === MATCHING_SUCCESS) {
-      dispatch(setTrip({ id: trip.id }));
-      dispatch(setRider({ id: trip.rider.id }));
       return setDriverStatus(DRIVER_MATCHING_SUCCESS);
     }
     showAlert(data.sendResponse);

--- a/client/src/pages/DriverWaitingPage.tsx
+++ b/client/src/pages/DriverWaitingPage.tsx
@@ -8,12 +8,15 @@ import { GET_TRIP_STATUS } from '../queries/trip';
 import { ADD_DRIVER_POSITION } from '../queries/driver';
 import { LISTEN_DRIVER_CALL } from '../queries/callRequest';
 
+import { setTrip } from '../slices/tripSlice';
+
 import { DRIVER_MATCHING_SUCCESS, DRIVER_POPUP, DRIVER_IGNORED, DRIVER_WAITING } from '../constants/driverStatus';
 import { OPEN } from '../constants/tripStatus';
 
 import DriverCurrentPositionMap from '../components/containers/DriverCurrentPositionMap';
 import DriverPopup from '../components/presentational/DriverPopup';
 import LogoutButton from '../components/presentational/LogoutButton';
+import { useDispatch } from 'react-redux';
 
 const LogoutPosition = styled.div`
   position: absolute;
@@ -26,9 +29,10 @@ const DRIVER_POSITION_UPDATE_TIME = 1000;
 function DriverWaitingPage() {
   //TODO: 이 페이지 전체를 container로 이동
   const history = useHistory();
+  const dispatch = useDispatch();
 
   const [riderCalls, setRiderCalls] = useState([]);
-  const [trip, setTrip] = useState({
+  const [currentTrip, setCurrentTrip] = useState({
     id: undefined,
     rider: undefined,
     origin: undefined,
@@ -38,7 +42,7 @@ function DriverWaitingPage() {
     estimatedTime: undefined,
     estimatedDistance: undefined,
   },
-  ); //TODO: type 다시 지정
+  );
   const [driverStatus, setDriverStatus] = useState(DRIVER_WAITING);
   const [count, setCount] = useState(0);
   const [driverPos, setDriverPos] = useState({ lat: 0, lng: 0 });
@@ -95,7 +99,7 @@ function DriverWaitingPage() {
 
   useEffect(() => {
     if (driverStatus === DRIVER_WAITING && riderCalls[0]) {
-      setTrip(riderCalls[0]);
+      setCurrentTrip(riderCalls[0]);
       getTripStatus({ variables: { id: riderCalls[0].id } });
     }
   }, [riderCalls]);
@@ -114,6 +118,7 @@ function DriverWaitingPage() {
       setRiderCalls(riderCalls.slice(1));
     }
     if (driverStatus === DRIVER_MATCHING_SUCCESS) {
+      dispatch(setTrip({ id: currentTrip.id }));
       setRiderCalls([]);
       history.push('/driver/pickup');
     }
@@ -131,7 +136,7 @@ function DriverWaitingPage() {
     <>
       {driverStatus === DRIVER_POPUP &&
       <DriverPopup
-        trip={trip}
+        trip={currentTrip}
         setDriverStatus={setDriverStatus}
       />}
       <DriverCurrentPositionMap driverPos={driverPos}/>

--- a/client/src/pages/DriverWaitingPage.tsx
+++ b/client/src/pages/DriverWaitingPage.tsx
@@ -48,7 +48,7 @@ function DriverWaitingPage() {
   const [driverPos, setDriverPos] = useState({ lat: 0, lng: 0 });
 
   const { data: driverListenData } = useSubscription(LISTEN_DRIVER_CALL);
-  const [getTripStatus, { data: tripStatusData }] = useLazyQuery(GET_TRIP_STATUS, { fetchPolicy: 'no-cache' });
+  const [getTripStatus, { data: tripStatusData }] = useLazyQuery(GET_TRIP_STATUS, { fetchPolicy: 'network-only' });
   const [updateDriverPosition] = useMutation(ADD_DRIVER_POSITION, { variables: driverPos });
 
   const getDriverPosition = () => {
@@ -105,11 +105,13 @@ function DriverWaitingPage() {
   }, [riderCalls]);
 
   useEffect(() => {
-    if (!!tripStatusData && tripStatusData.tripStatus === OPEN) {
+    if (!!tripStatusData && tripStatusData.trip.status === OPEN) {
       setDriverStatus(DRIVER_POPUP);
       return;
     }
-    setDriverStatus(DRIVER_IGNORED);
+    if (driverStatus !== DRIVER_POPUP) {
+      setDriverStatus(DRIVER_IGNORED);
+    }
   }, [tripStatusData]);
 
   useEffect(() => {

--- a/client/src/pages/TripClosePage.tsx
+++ b/client/src/pages/TripClosePage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useQuery } from '@apollo/client';
 
@@ -10,6 +10,7 @@ import { WhiteSpace, Icon, Steps } from 'antd-mobile';
 import styled from 'styled-components';
 
 import { GET_TRIP } from '../queries/trip';
+import { setTrip } from '../slices/tripSlice';
 
 const Page = styled.div`
   /* position: absolute; */
@@ -54,6 +55,8 @@ const Title = styled.h1`
 `;
 
 function TripClosePage() {
+  const dispatch = useDispatch();
+  const history = useHistory();
   const [tripInfo, setTripInfo] = useState(null);
   const { loginReducer, tripReducer }: any = useSelector(state => state);
   const { trip } = tripReducer;
@@ -70,6 +73,12 @@ function TripClosePage() {
       </g>
     </svg>
   );
+
+  const handleClickConfirm = () => {
+    dispatch(setTrip({ id: undefined }));
+    history.push(nextPage);
+  };
+
   useEffect(() => {
     if (tripData) {
       setTripInfo(tripData.trip);
@@ -88,9 +97,7 @@ function TripClosePage() {
             <Steps.Step title="하차지" icon={customIcon()} description={tripInfo && tripInfo.destination.address} />
           </Steps>
           <WhiteSpace />
-          <Link to={nextPage}>
-            <Button>확인</Button>
-          </Link>
+          <Button onClick={handleClickConfirm}>확인</Button>
         </Paper>
       }
     </Page>

--- a/client/src/queries/callRequest.ts
+++ b/client/src/queries/callRequest.ts
@@ -30,10 +30,22 @@ subscription {
 
 export const NOTIFY_RIDER_CALL = gql`
 mutation driverCall($origin: TripPlaceInput!, $destination: TripPlaceInput!, $startTime: String!, $estimatedTime: String!, $estimatedDistance: String!) {
-  driverCall(origin: $origin, destination: $destination, startTime: $startTime, estimatedTime: $estimatedTime, estimatedDistance: $estimatedDistance)
+  driverCall(origin: $origin, destination: $destination, startTime: $startTime, estimatedTime: $estimatedTime, estimatedDistance: $estimatedDistance){
+    result
+    trip{
+      id
+      status
+    }
+  }
 }`;
 
 export const RE_NOTIFY_RIDER_CALL = gql`
 mutation driveRecall($id: ID!) {
-  driverRecall(id: $id)
+  driverRecall(id: $id){
+    result
+    trip{
+      id
+      status
+    }
+  }
 }`;

--- a/client/src/queries/driver.ts
+++ b/client/src/queries/driver.ts
@@ -4,17 +4,12 @@ export const NOTIFY_DRIVER_STATE = gql`
 mutation driverStateNotify(
   $tripId:String,
   $driverPosition:DriverPositionInput,
-  $onBoard:Boolean,
-  $isDrop:Boolean){
+){
     driverStateNotify(
       tripId:$tripId,
       driverPosition:$driverPosition,
-      onBoard:$onBoard
-      isDrop:$isDrop
     ){
       tripId
-      onBoard
-      isDrop
       driverPosition {
         lat
         lng
@@ -29,7 +24,10 @@ export const LISTEN_MATCHED_RIDER_STATE = gql`
       tripId
       latitude
       longitude
-      isCancel
+      trip{
+        id
+        status
+      }
     }
   }
 `;

--- a/client/src/queries/driverResponded.ts
+++ b/client/src/queries/driverResponded.ts
@@ -3,15 +3,23 @@ import { gql } from '@apollo/client';
 export const LISTEN_DRIVER_RESPONSE = gql`
   subscription {
     driverResponded { 
-      tripId
-      driverId
-      response
+      id
+      driver{
+        id
+      }
+      status
     }
   }
 `;
 
 export const NOTIFY_DRIVER_RESPONSE = gql`
 mutation responseMutation($response:String!,$riderId:ID!,$tripId:ID!){
-  sendResponse(response:$response,riderId:$riderId,tripId:$tripId)
+  sendResponse(response:$response,riderId:$riderId,tripId:$tripId){
+    result
+    trip{
+      id
+      status
+    }
+  }
 }
 `;

--- a/client/src/queries/rider.ts
+++ b/client/src/queries/rider.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
 export const NOTIFY_RIDER_STATE = gql`
-  mutation notifyRiderState($tripId: ID!, $latitude: Float, $longitude: Float, $isCancel: Boolean) {
-    notifyRiderState(tripId: $tripId, latitude: $latitude, longitude: $longitude, isCancel: $isCancel)
+  mutation notifyRiderState($tripId: ID!, $latitude: Float, $longitude: Float) {
+    notifyRiderState(tripId: $tripId, latitude: $latitude, longitude: $longitude)
   }
 `;
 
@@ -10,12 +10,14 @@ export const LISTEN_MATCHED_DRIVER_STATE = gql`
 	subscription matchedDriverState($tripId: ID!) {
 		matchedDriverState(tripId: $tripId) {
 		tripId
-		onBoard
-	    isDrop
 	    driverPosition {
 				lat
 				lng
-			}
+		}
+		trip{
+			id
+			status
+		}
 	  }
 	}
 `;

--- a/client/src/queries/trip.ts
+++ b/client/src/queries/trip.ts
@@ -2,13 +2,19 @@ import { gql } from '@apollo/client';
 
 export const CANCEL_TRIP = gql`mutation cancelCall($id:ID!){
   cancelTrip(id:$id){
-    id
     result
+    trip{
+      id
+      status
+    }
   }
 }`;
 
 export const GET_TRIP_STATUS = gql`query getStatus($id:ID!){
-  tripStatus(id:$id)
+  trip(id:$id){
+    id
+    status
+  }
 }`;
 
 export const GET_PICK_UP_POSITION = gql`query pickUpPos($id:ID!){
@@ -68,6 +74,14 @@ export const GET_TRIP = gql`query getTrip($id:ID!){
   }
 }`;
 
+export const TRIP_STATUS = gql`query ($id:ID!){
+  tripStatus(id:$id){
+    id
+    status
+  }
+}
+`;
+
 export const GET_TRIP_BEFORE_MATCHING = gql`query getTrip($id:ID!){
   trip(id:$id){
     id
@@ -98,6 +112,10 @@ export const ADD_TRIP_STATUS = gql`
   mutation setTripStatus($tripId: ID!, $newTripStatus: String!) {
     setTripStatus(tripId:$tripId, newTripStatus:$newTripStatus) {
       result
+      trip{
+        id
+        status
+      }
     }
   }
 `;

--- a/client/src/queries/verify.ts
+++ b/client/src/queries/verify.ts
@@ -4,6 +4,7 @@ export const VERIFY_USER_ROLE = gql`
   query verifyUser {
     verifyUser {
       role
+      tripId
     }
   }
 `;

--- a/client/src/routes/ValidateTripStatus.tsx
+++ b/client/src/routes/ValidateTripStatus.tsx
@@ -1,0 +1,79 @@
+import React, { FC, useEffect, useMemo } from 'react';
+
+import { useHistory } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { useQuery } from '@apollo/client';
+
+import { TRIP_STATUS } from '../queries/trip';
+import { setTrip, selectTripReducer } from '../slices/tripSlice';
+import { selectLoginReducer } from '../slices/loginSlice';
+import LoadingView from '../components/presentational/LoadingView';
+
+const ValidateTripStatus = (Component:FC, type:string):FC => () => {
+  const history = useHistory();
+  const dispatch = useDispatch();
+
+  const { trip } = useSelector(selectTripReducer);
+  const { loginRole } = useSelector(selectLoginReducer);
+
+  const { loading, data: tripStatus } = useQuery(TRIP_STATUS, {
+    variables: { id: trip.id },
+    fetchPolicy: 'network-only',
+    skip: !trip.id,
+  });
+
+  const status = useMemo(() => (!trip.id) ? 'main' : !loading ? tripStatus.tripStatus.status : undefined, [tripStatus]);
+
+  useEffect(() => {
+    if (status && status !== type) {
+      switch (status) {
+        case 'main':
+          if (loginRole === 'rider') {
+            history.push('/rider/setcourse');
+            break;
+          }
+          if (loginRole === 'driver') {
+            history.push('/driver/main');
+            break;
+          }
+        case 'cancel':
+          dispatch(setTrip({ id: undefined }));
+          if (loginRole === 'rider') {
+            history.push('/rider/setcourse');
+            break;
+          }
+          if (loginRole === 'driver') {
+            history.push('/driver/main');
+            break;
+          }
+        case 'open':
+          if (loginRole === 'rider') {
+            history.push('/rider/waiting');
+            break;
+          }
+          if (loginRole === 'driver') {
+            history.push('/driver/main');
+            break;
+          }
+        case 'matched':
+          history.push(`/${loginRole}/pickup`);
+          break;
+        case 'onBoard':
+          history.push(`/${loginRole}/driving`);
+          break;
+        case 'close':
+          history.push(`/${loginRole}/tripend`);
+          break;
+      }
+    }
+  }, [status]);
+
+  if (loading) {
+    return <LoadingView />;
+  }
+
+  return (<>{!!status && status === type && <Component />}</>);
+}
+;
+
+export default ValidateTripStatus;

--- a/client/src/slices/loginSlice.ts
+++ b/client/src/slices/loginSlice.ts
@@ -12,6 +12,10 @@ const { actions, reducer } = createSlice({
   },
 });
 
+export const selectLoginReducer = (state: any) => {
+  return state.loginReducer;
+};
+
 export const {
   setLoginRole,
 } = actions;

--- a/client/src/slices/tripSlice.ts
+++ b/client/src/slices/tripSlice.ts
@@ -3,7 +3,7 @@ import { createSlice } from '@reduxjs/toolkit';
 const { actions, reducer } = createSlice({
   name: 'trip',
   initialState: {
-    trip: { id: '' },
+    trip: { id: undefined },
     rider: { id: '', name: '', email: '' },
     driver: { id: '', name: '', carType: '', plateNumber: '', description: '', profileImage: '' },
   },

--- a/server/src/graphql/resolvers/trip.ts
+++ b/server/src/graphql/resolvers/trip.ts
@@ -86,9 +86,9 @@ export default {
       const user = context.req.user;
       const { statuses } = args;
       if (!statuses) {
-        return await Trip.getMyTrips(user.data._id, user.isDriver, ['open', 'matched', 'onBoard', 'close', 'cancel']);
+        return await Trip.getMyTrip(user.data._id, user.isDriver, ['open', 'matched', 'onBoard', 'close', 'cancel']);
       }
-      return await Trip.getMyTrips(user.data._id, user.isDriver, statuses);
+      return await Trip.getMyTrip(user.data._id, user.isDriver, statuses);
     },
   },
   Mutation: {

--- a/server/src/graphql/resolvers/verify.ts
+++ b/server/src/graphql/resolvers/verify.ts
@@ -1,3 +1,5 @@
+import { Trip } from '../../services';
+
 export default {
   Query: {
     async user(parent: any, args:any, context: any, info: any) {
@@ -5,7 +7,9 @@ export default {
       return data;
     },
     async verifyUser(parent: any, args: {}, context: any, info: any) {
-      return { role: context.req.user ? context.req.user.isDriver ? 'driver' : 'rider' : 'unknown' };
+      const user = context.getUser();
+      const trip = user ? await Trip.getMyTrip(user.data._id, user.isDriver, ['open', 'matched', 'onBoard']) : undefined ;
+      return { role: context.req.user ? context.req.user.isDriver ? 'driver' : 'rider' : 'unknown', tripId: trip?._id };
     },
   },
 };

--- a/server/src/graphql/types/driver.graphql
+++ b/server/src/graphql/types/driver.graphql
@@ -20,18 +20,16 @@ type Mutation {
     response: String!, 
     riderId: ID!,
     tripId: ID!
-  ): String @isAuthorized
+  ): Result @isAuthorized
 
   driverStateNotify(
     tripId: String
     driverPosition: DriverPositionInput
-    onBoard: Boolean
-    isDrop: Boolean
   ): driverStateNotify @isAuthorized
 
   updateDriverPosition(
     lat:Float, lng:Float
-  ): Result @isAuthorized
+  ): updateResult @isAuthorized
 }
 
 type Subscription {
@@ -68,8 +66,7 @@ input DriverPositionInput {
 type driverStateNotify {
   tripId: ID!
   driverPosition: Position
-  onBoard: Boolean
-  isDrop: Boolean
+  trip: Trip
 }
 
 type Position {
@@ -82,6 +79,6 @@ type driverListenResult{
   driverIds: [String]
 }
 
-type Result {
+type updateResult {
   result: String
 }

--- a/server/src/graphql/types/rider.graphql
+++ b/server/src/graphql/types/rider.graphql
@@ -18,17 +18,17 @@ type Mutation {
     startTime: String!,
     estimatedTime: String!,
     estimatedDistance: String!
-  ): String @isAuthorized
+  ): CallResult @isAuthorized
   
   driverRecall(
     id:ID!
-  ): String @isAuthorized
+  ): CallResult @isAuthorized
 
-  notifyRiderState(tripId: ID!, latitude: Float, longitude: Float, isCancel: Boolean): Boolean @isAuthorized
+  notifyRiderState(tripId: ID!, latitude: Float, longitude: Float): Boolean @isAuthorized
 }
 
 type Subscription {
-  driverResponded: DriverResponse
+  driverResponded: Trip
 
   matchedRiderState(tripId: ID!): RiderState
 }
@@ -50,13 +50,18 @@ type RiderState {
   tripId: ID!
   latitude: Float
   longitude: Float
-  isCancel: Boolean
+  trip: Trip
 }
 
 type DriverResponse{
   driverId: ID!
   tripId: ID!
   response: String!
+}
+
+type CallResult{
+  result: String!
+  trip: Trip
 }
 
 

--- a/server/src/graphql/types/trip.graphql
+++ b/server/src/graphql/types/trip.graphql
@@ -4,7 +4,7 @@ type Mutation {
     destination: TripPlaceInput!,
     startTime: String!,
   ) : Trip @isAuthorized
-  cancelTrip(id: ID!): CancelResult @isAuthorized
+  cancelTrip(id: ID!): Result @isAuthorized
   setTripStatus(tripId: ID!, newTripStatus: String!): Result @isAuthorized
   addChatting(tripId: ID!, chattingInput: ChattingInput!): Chatting @isAuthorized
   setArrivals(tripId: ID!, arrivalTime: String!, destination: TripPlaceInput): Trip @isAuthorized
@@ -12,7 +12,7 @@ type Mutation {
 
 type Query {
   trip(id: ID!):Trip @isAuthorized
-  tripStatus(id: ID!): String! @isAuthorized
+  tripStatus(id: ID!): TripStatus! @isAuthorized
   chattings(id: ID!): [Chatting] @isAuthorized
   myTrips(statuses: [String]): [Trip] @isAuthorized
 }
@@ -21,6 +21,11 @@ input TripPlaceInput {
   address: String!
   latitude: Float!
   longitude: Float!
+}
+
+type TripStatus{
+  id: ID!
+  status: String!
 }
 
 type Trip {

--- a/server/src/graphql/types/verify.graphql
+++ b/server/src/graphql/types/verify.graphql
@@ -19,4 +19,5 @@ type User {
 
 type VerifiedUser {
   role: String!
+  tripId: ID
 }

--- a/server/src/repositories/trip.ts
+++ b/server/src/repositories/trip.ts
@@ -9,7 +9,7 @@ interface PlaceInterface {
 type Status = 'open' | 'matched' | 'onBoard' | 'close' | 'cancel';
 
 export default {
-  findById: async(id) => {
+  findById: async(id:string) => {
     return await Trip.findById(id);
   },
   create: async (payload) => {

--- a/server/src/repositories/trip.ts
+++ b/server/src/repositories/trip.ts
@@ -19,7 +19,7 @@ export default {
     return await Trip.findById(id, 'status');
   },
   update: async(id, payload) => {
-    return await Trip.findByIdAndUpdate(id, payload);
+    return await Trip.findByIdAndUpdate(id, payload, { new: true });
   },
   open: async (
     riderEmail: string,
@@ -52,11 +52,11 @@ export default {
   setArrivals: async (tripId: string, realArrivalTime: Date, realDestination: {address: string, latitude:number, longitude: number}) => {
     return await Trip.findOneAndUpdate({ _id: tripId }, { arrivalTime: realArrivalTime, destination: realDestination }, { new: true });
   },
-  getMyTrips: async (userId: string | object, isDriver: boolean, statuses?: Status[]) => {
+  getMyTrip: async (userId: string | object, isDriver: boolean, statuses?: Status[]) => {
     if (isDriver) {
-      return await Trip.find({ status: { $in: statuses }, 'driver._id': userId });
+      return await Trip.findOne({ status: { $in: statuses }, 'driver._id': userId });
     } else {
-      return await Trip.find({ status: { $in: statuses }, 'rider._id': userId });
+      return await Trip.findOne({ status: { $in: statuses }, 'rider._id': userId });
     }
   },
 };

--- a/server/src/services/trip.ts
+++ b/server/src/services/trip.ts
@@ -25,35 +25,6 @@ type Status = 'open' | 'matched' | 'onBoard' | 'close' | 'cancel';
 export default {
   get: async({ id }) => {
     try {
-      const trip = await Trip.findById(id);
-      const rider = trip?.rider;
-      const driver = trip?.driver;
-      const origin = trip?.origin;
-      const destination = trip?.destination;
-      const startTime = trip?.startTime;
-      const arrivalTime = trip?.arrivalTime;
-      const status = trip?.status;
-      const chattings = trip?.chattings;
-      const estimatedTime = trip?.estimatedTime;
-      const estimatedDistance = trip?.estimatedDistance;
-      return {
-        id: trip?._id,
-        rider: { id: rider?._id, ...rider },
-        driver: { id: driver?._id, ...driver },
-        origin,
-        destination,
-        startTime,
-        arrivalTime,
-        status,
-        chattings,
-        estimatedTime,
-        estimatedDistance };
-    } catch (e) {
-      throw e.message;
-    }
-  },
-  getRecallData: async({ id }) => {
-    try {
       return await Trip.findById(id);
     } catch (e) {
       throw e.message;

--- a/server/src/services/trip.ts
+++ b/server/src/services/trip.ts
@@ -33,7 +33,7 @@ export default {
   getStatus: async({ id }) => {
     try {
       const result = await Trip.findOneStatus(id);
-      return result?.status;
+      return result;
     } catch (e) {
       throw e.message;
     }
@@ -58,8 +58,8 @@ export default {
   },
   cancel: async ({ id }) => {
     try {
-      await Trip.update(id, { status: 'cancel' });
-      return { id, result: 'canceled' };
+      const trip = await Trip.update(id, { status: 'cancel' });
+      return { result: 'canceled', trip };
     } catch (e) {
       throw e.message;
     }
@@ -97,7 +97,7 @@ export default {
   setArrivals: async (tripId: string, arrivalTime: Date, destination: {address: string, latitude: number, longitude: number}) => {
     return await Trip.setArrivals(tripId, arrivalTime, destination);
   },
-  getMyTrips: async(userId: string | object, isDriver: boolean, statuses?: Status[]) => {
-    return await Trip.getMyTrips(userId, isDriver, statuses);
+  getMyTrip: async(userId: string | object, isDriver: boolean, statuses?: Status[]) => {
+    return await Trip.getMyTrip(userId, isDriver, statuses);
   },
 };


### PR DESCRIPTION
## 개요
새로고침, 페이지 이동 시 운행상태에 따른 라우팅
운행상태가 업데이트 될때 cache도 업데이트

## 작업사항
- 운행상태가 matched, onBoard, cancel, close 등으로 업데이트 될때, cache의 status 도 변경하기 위해서 return field에 `Trip` 을 추가
- 변경된 `typeDef`에 맞춰 `query` 변경 후 그에 맞게 데이터 조회
- 페이지가 라우팅 될때, 운행 상태 확인 후 해당 페이지에 맞는 상태인지 비교
- 맞지않을 경우 맞는 페이지로 재 라우팅

## 기타
라우팅 주요 코드는 `client/src/routes` 디렉토리의 `validateTripStatus.tsx`, `RouteIf.tsx` 입니다!
PR 단위가 너무 커서 죄송합니다......File changed는 여러개인데 코드 수정 부분은 많지 않습니다😢