### PR TITLE
DriverPickUpForm, RiderPickUpForm 필요없는 네트워크통신, 렌더링 수정

### DIFF
--- a/client/src/components/containers/DriverPickUpForm.tsx
+++ b/client/src/components/containers/DriverPickUpForm.tsx
@@ -71,8 +71,8 @@ export default function DriverPickUpForm() {
   };
 
   useEffect(() => {
+    getDriverPosition();
     let timerId = setTimeout(function tick() {
-      getDriverPosition();
       if (JSON.stringify(driverPos) !== JSON.stringify(newDriverPos)) {
         setDriverPos(newDriverPos);
       }

--- a/client/src/components/containers/DriverPickUpForm.tsx
+++ b/client/src/components/containers/DriverPickUpForm.tsx
@@ -20,13 +20,15 @@ const INIT_POS = {
   lng: -122.46,
 };
 
+const UPDATE_POS_INTERVAL = 1000;
+
 export default function DriverPickUpForm() {
   const dispatch = useDispatch();
   const history = useHistory();
   const alert = Modal.alert;
   const [driverPos, setDriverPos] = useState(INIT_POS);
+  const [newDriverPos, setNewDriverPos] = useState(INIT_POS);
   const [riderPos, setRiderPos] = useState({ lat: undefined, lng: undefined });
-  const [count, setCount] = useState(0);
   const { originPosition }: any = useSelector(selectMapReducer);
   const { trip }: any = useSelector(selectTripReducer);
 
@@ -50,7 +52,7 @@ export default function DriverPickUpForm() {
       lat: position.coords.latitude,
       lng: position.coords.longitude,
     };
-    setDriverPos(pos);
+    setNewDriverPos(pos);
   };
 
   const navError = (): any => {
@@ -69,14 +71,17 @@ export default function DriverPickUpForm() {
   };
 
   useEffect(() => {
-    getDriverPosition();
-    const timer = setTimeout(() => {
-      setCount(count + 1);
-    }, 1000);
+    let timerId = setTimeout(function tick() {
+      getDriverPosition();
+      if (JSON.stringify(driverPos) !== JSON.stringify(newDriverPos)) {
+        setDriverPos(newDriverPos);
+      }
+      timerId = setTimeout(tick, UPDATE_POS_INTERVAL);
+    }, UPDATE_POS_INTERVAL);
     return () => {
-      clearTimeout(timer);
+      clearTimeout(timerId);
     };
-  }, [count]);
+  });
 
   useEffect(() => {
     notifyDriverState({ variables: { tripId: trip.id, driverPosition: driverPos } });

--- a/client/src/components/containers/RiderPickUpForm.tsx
+++ b/client/src/components/containers/RiderPickUpForm.tsx
@@ -68,8 +68,8 @@ export default function RiderPickUpForm() {
   };
 
   useEffect(() => {
+    getRiderPosition();
     let timerId = setTimeout(function tick() {
-      getRiderPosition();
       if (JSON.stringify(riderPos) !== JSON.stringify(newRiderPos)) {
         setRiderPos(newRiderPos);
       }

--- a/client/src/components/containers/RiderPickUpForm.tsx
+++ b/client/src/components/containers/RiderPickUpForm.tsx
@@ -18,12 +18,14 @@ const INIT_POS = {
   lng: -122.4782,
 };
 
+const UPDATE_POS_INTERVAL = 1000;
+
 export default function RiderPickUpForm() {
   const history = useHistory();
   const dispatch = useDispatch();
   const [riderPos, setRiderPos] = useState(INIT_POS);
+  const [newRiderPos, setNewRiderPos] = useState(INIT_POS);
   const [driverPos, setDriverPos] = useState(INIT_POS);
-  const [count, setCount] = useState(0);
   const { originPosition }: any = useSelector(selectMapReducer);
   const { trip }: any = useSelector(selectTripReducer);
 
@@ -47,7 +49,7 @@ export default function RiderPickUpForm() {
       lat: position.coords.latitude,
       lng: position.coords.longitude,
     };
-    setRiderPos(pos);
+    setNewRiderPos(pos);
   };
 
   const navError = (): any => {
@@ -66,11 +68,17 @@ export default function RiderPickUpForm() {
   };
 
   useEffect(() => {
-    getRiderPosition();
-    setTimeout(() => {
-      setCount(count + 1);
-    }, 1000);
-  }, [count]);
+    let timerId = setTimeout(function tick() {
+      getRiderPosition();
+      if (JSON.stringify(riderPos) !== JSON.stringify(newRiderPos)) {
+        setRiderPos(newRiderPos);
+      }
+      timerId = setTimeout(tick, UPDATE_POS_INTERVAL);
+    }, UPDATE_POS_INTERVAL);
+    return () => {
+      clearTimeout(timerId);
+    };
+  });
 
   useEffect(() => {
     notifyRiderState({ variables: { tripId: trip.id, latitude: riderPos.lat, longitude: riderPos.lng } });


### PR DESCRIPTION
## 개요

DriverPickUpForm, RiderPickUpForm에서 위치가 변경되지 않아도 업데이트 요청이 보내지고, 리렌더링이 계속되는 문제 해결

## 작업사항

- newRiderPos, newDriverPos 상태 추가
- useEffect에 중첩 setTimeout으로 현재 좌표를 불러오는 함수 호출하고 업데이트하는 작업 스케줄링하도록 수정
- 실제로 위치가 변경되었는지 확인한 후에 업데이트하도록 수정
- useEffect 변경에 따라 count 상태 필요없어서 제거

## 기타

- 네트워크탭을 확인하면 이전에 graphql로 계속 요청이 보내지는데 이제 실제 업데이트되었을 때만 요청이 보내짐
- 지도에서 우측 하단에 축척 표시하는 부분이 계속 깜빡였는데 더이상 깜빡이지 않음